### PR TITLE
Fix spawner dupe and objectify e.getBock()

### DIFF
--- a/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
+++ b/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
@@ -1837,17 +1837,19 @@ public class SlimefunSetup {
 			@Override
 			public boolean onBlockBreak(BlockBreakEvent e, ItemStack item, int fortune, List<ItemStack> drops) {
 				if (SlimefunManager.isItemSimiliar(item, SlimefunItems.PICKAXE_OF_CONTAINMENT, true)) {
-					if (e.getBlock().getType() != Material.SPAWNER) return true;
-					BlockStorage.clearBlockInfo(e.getBlock());
+					Block b = e.getBlock(); // Refactored it into this so we don't need to call e.getBlock() all the time.
+					if (b.getType() != Material.SPAWNER || BlockStorage.hasBlockInfo(b)) return true; 
+					// If the spawner's BlockStorage has BlockInfo, then it's not a vanilla spawner and shouldn't give a broken spawner.
+					BlockStorage.clearBlockInfo(b);
 					ItemStack spawner = SlimefunItems.BROKEN_SPAWNER.clone();
 					ItemMeta im = spawner.getItemMeta();
 					List<String> lore = im.getLore();
 					for (int i = 0; i < lore.size(); i++) {
-						if (lore.get(i).contains("<Type>")) lore.set(i, lore.get(i).replace("<Type>", StringUtils.format(((CreatureSpawner) e.getBlock().getState()).getSpawnedType().toString())));
+						if (lore.get(i).contains("<Type>")) lore.set(i, lore.get(i).replace("<Type>", StringUtils.format(((CreatureSpawner) b.getState()).getSpawnedType().toString())));
 					}
 					im.setLore(lore);
 					spawner.setItemMeta(im);
-					e.getBlock().getLocation().getWorld().dropItemNaturally(e.getBlock().getLocation(), spawner);
+					b.getLocation().getWorld().dropItemNaturally(b.getLocation(), spawner);
 					e.setExpToDrop(0);
 					return true;
 				}


### PR DESCRIPTION
A) 
Fixed spawner dupe. 

Reproducing:

A) Pickaxe of Containment
B) Try to break a **reinforced** spawner
C) You will get a reinforced spawner and a broken spawner.

Fix:

Add the if-statement which basically boils down to `if (BlockStorage.hasBlockInfo(b)) return true;`
This will nullify the event. If the if-statement resolves to `true` then it will is not a vanilla spawner and
the containment pick should therefore not work.

The actual implementation is `if (b.getType() != Material.SPAWNER || BlockStorage.hasBlockInfo(b)) return true; ` and is just a way to bake in the relatively simple boolean into a similar check.

B)
Added some quick refactoring, so instead of doing,
`foo(e.getBlock);`
you now do,
`Block b = e.getBlock();`
such that the call is `foo(b);`